### PR TITLE
Provide error-checking for overlapping availability timings

### DIFF
--- a/schedule_lessons/dashboard/static/dashboard/css/edit_availability.css
+++ b/schedule_lessons/dashboard/static/dashboard/css/edit_availability.css
@@ -245,6 +245,13 @@ tr #deleteAvailability {
   left: -9999px;
 }
 
+.error-list {
+  font-family: avenir-next;
+  color: #D14F52;
+  margin-top: 0.6%;
+  margin-bottom: 0;
+}
+
 #addBtn {
   font-family: anson;
   padding: 2px 35px;

--- a/schedule_lessons/templates/dashboard/edit_availability.html
+++ b/schedule_lessons/templates/dashboard/edit_availability.html
@@ -146,6 +146,7 @@
           {% endif %}
           <input id="timeZoneInput" type="text" name="timezoneInfo" value="" hidden>
           <input id="submit" type="submit">
+          <p class="error-list">{{ overlap_time_error }}</p>
           <div class="center">
             <a id="addBtn" href="#">ADD</a>
           </div>


### PR DESCRIPTION
## Overview

Prior to this branch, no errors were returned if an availability timing overlapped with another timing. This is no longer an issue. There are limitations to this fix as the values of what they entered as timings
and day are not returned if the error is triggered, meaning the user has to remember what availability he set prior to the error. This is not good and needs to be remedied in a future branch.