### PR TITLE
add back values from local_settings.py

### DIFF
--- a/schedule_lessons/local_settings.py
+++ b/schedule_lessons/local_settings.py
@@ -1,0 +1,5 @@
+EMAIL_HOST = 'smtp.zoho.com'
+VERIFY_USER_EMAIL = 'verify.user@schedulearn.com'
+FORGET_PASSWORD_EMAIL = 'reset.password@schedulearn.com'
+EMAIL_HOST_PASSWORD = 'Schedulearn2018'
+EMAIL_PORT = 587


### PR DESCRIPTION
@Nppatel97 

to prevent these errors:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 35, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 128, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/shreyasdevalapurkar/Documents/schedulearn/schedule_lessons/accounts/views.py", line 68, in signup_view
    host=EMAIL_HOST,
NameError: name 'EMAIL_HOST' is not defined
```