### PR TITLE
#126: Send notification and an email when a lesson has been cancelled

### DIFF
--- a/schedule_lessons/dashboard/static/dashboard/js/schedule_lesson.js
+++ b/schedule_lessons/dashboard/static/dashboard/js/schedule_lesson.js
@@ -91,15 +91,16 @@ $(document).ready(function () {
             $('#endTimeLabel').removeClass('label-error');
             $('#endTimeInput').removeClass('input-error');
           }
-          if (response.bigger_start_time_error) {
+          if (response.no_relationship_error) {
+            $('.error-list').html("You can only schedule lessons with people you are friends with.");
+          } else if (response.bigger_start_time_error) {
             $('.error-list').html(response.bigger_start_time_error);
           } else if (response.past_lesson_error) {
             $('.error-list').html(response.past_lesson_error);
-          }
-          if (response.pending_relationship_error) {
+          } else if (response.pending_relationship_error) {
             $('.error-list').html("You can only schedule lessons with people who have accepted your friend request.");
-          } else if (response.no_relationship_error) {
-            $('.error-list').html("You can only schedule lessons with people you are friends with.");
+          } else if (response.non_available_time_error) {
+            $('.error-list').html(response.non_available_time_error);
           }
         }
       },

--- a/schedule_lessons/dashboard/views.py
+++ b/schedule_lessons/dashboard/views.py
@@ -995,9 +995,15 @@ def error_check_and_save_lesson(request, lesson, context):
                 lesson_end = lesson.end_time
                 availability_end = availability.end_time
                 if (lesson_start.weekday() == availability_start.weekday() and
-                    lesson_start.time() > availability_start.time() and
-                    lesson_end.time() < availability_end.time()):
+                    ((lesson_end.time() < lesson_start.time() and
+                    availability_end.time() < availability_start.time() and
+                    lesson_start.time() >= availability_start.time() and
+                    lesson_end.time() <= availability_end.time()) or
+                    (lesson_end.time() > lesson_start.time() and
+                    availability_end.time() < availability_start.time() and
+                    lesson_start.time() >= availability_start.time()))):
                     context['non_available_time_error'] = False
+
         if context.get('non_available_time_error'):
             context['non_available_time_error'] = ("Please choose timings that "
             "are within the availabilities of the person that you're trying to "

--- a/schedule_lessons/schedule_lessons/local_settings.py
+++ b/schedule_lessons/schedule_lessons/local_settings.py
@@ -1,5 +1,6 @@
 EMAIL_HOST = 'smtp.zoho.com'
 VERIFY_USER_EMAIL = 'verify.user@schedulearn.com'
+SCHEDULER_NOTIFY_EMAIL = 'scheduler.notify@schedulearn.com'
 EMAIL_HOST_USER = VERIFY_USER_EMAIL
 FORGET_PASSWORD_EMAIL = 'reset.password@schedulearn.com'
 EMAIL_HOST_PASSWORD = 'Schedulearn2018'


### PR DESCRIPTION
Addresses Issue #126 by sending a mail and a notification when a lesson is cancelled. If a lesson is cancelled when it was in the pending state by the person who created it, then no notification is sent out.